### PR TITLE
build, add paging for contributors

### DIFF
--- a/actions/build.js
+++ b/actions/build.js
@@ -30,13 +30,23 @@ const main = async _ => {
                 })
                 const data = response.data
                 data.created_at_formatted = new Date(data.created_at).toUTCString()
-                data.updated_at_formatted = new Date(data.updated_at).toUTCString()                
+                data.updated_at_formatted = new Date(data.updated_at).toUTCString()
 
-                let contributors = await octokit.request('GET /repos/{owner}/{repo}/contributors', {
-                    owner: parts.owner,
-                    repo: parts.name
-                })
-                data.contributors = contributors.data
+                data.contributors = [];
+                let page = 1;
+                while (true) {
+                    let contributors = await octokit.request('GET /repos/{owner}/{repo}/contributors', {
+                        owner: parts.owner,
+                        repo: parts.name,
+                        per_page: 100,
+                        page
+                    })
+                    if (contributors.data.length === 0) {
+                      break;
+                    }
+                    page++;
+                    data.contributors = data.contributors.concat(contributors.data)
+                }
 
                 if(data.license.url){
                     const parts = gh(data.license.url)


### PR DESCRIPTION
By default the github APIs return the first 30 entries, finding contributors for a repo will now find all via paging.

