### PR TITLE
entries.md: fix watchers

### DIFF
--- a/actions/template.js
+++ b/actions/template.js
@@ -2,7 +2,7 @@ module.exports = `
 ## {{data.name}}: {{data.description}}
 [{{data.html_url}}]({{data.html_url}})
 
-* Stars: {{data.stargazers_count}}, Forks: {{data.forks_count}}, Watchers: {{data.watchers_count}}
+* Stars: {{data.stargazers_count}}, Forks: {{data.forks_count}}, Watchers: {{data.subscribers_count}}
 * Open Issues: {{data.open_issues_count}}, Has Projects: {{data.has_projects}}, Has Wiki: {{data.has_wiki}}
 * Created At: {{data.created_at_formatted}}, Updated At: {{data.updated_at_formatted}}
 * License: {{#if data.license.html_url}}[{{data.license.name}}]({{data.license.html_url}}){{else}}{{data.license.name}}{{/if}}


### PR DESCRIPTION
in https://github.com/SAP-samples/sap-devtoberfest-2020/blob/master/entries.md

the number of stars and watchers are identical for all projects, example:
![image](https://user-images.githubusercontent.com/5888506/93661705-2603b800-fa5a-11ea-9350-2f0931539ad8.png)

instead try using the `subscribers_count` field, example https://api.github.com/repos/larshp/abapGit