### PR TITLE
Add https://github.com/mikezaschka/cds-dbm

### DIFF
--- a/entry.txt
+++ b/entry.txt
@@ -22,3 +22,4 @@ https://github.com/dirigiblelabs/sample-survey
 https://github.com/pawelwiejkut/bw_toolbox
 https://github.com/sapmentors/cds-scp-api
 https://github.com/jenkinsci/abap-ci-plugin
+https://github.com/mikezaschka/cds-dbm


### PR DESCRIPTION
Add project for cds model to database delta deployments with initial support for PostgresSQL (https://github.com/sapmentors/cds-pg).
The efforts started within cds-pg but has been extracted into its own library to easier add support for other databases in the future.