### PR TITLE
bmaciag/Devtoberfest-2020 does not exist anymore

### DIFF
--- a/entry.txt
+++ b/entry.txt
@@ -1,7 +1,6 @@
 https://github.com/sap-samples/sap-devtoberfest-2020
 https://github.com/js-soft/wdio-ui5
 https://github.com/sapmentors/cds-pg
-https://github.com/bmaciag/Devtoberfest-2020
 https://github.com/goreraks/abapGitcustomizing
 https://github.com/jrodriguez-rc/abap-dev-utilities
 https://github.com/marcellourbani/vscode_abap_remote_fs


### PR DESCRIPTION
https://github.com/bmaciag/Devtoberfest-2020 does not exist anymore, causing the build to fail, https://github.com/SAP-samples/sap-devtoberfest-2020/runs/1310566840?check_suite_focus=true

@bmaciag I guess you can always add a new repository, I could not find it if it has been renamed